### PR TITLE
Add -05 history entry for Deb Cooley's AD comments

### DIFF
--- a/draft-ietf-oauth-rfc8725bis.md
+++ b/draft-ietf-oauth-rfc8725bis.md
@@ -894,6 +894,10 @@ This document obsoletes RFC 8725 and provides several significant improvements a
 
 [[Note to RFC Editor: please remove before publication.]]
 
+## draft-ietf-oauth-rfc8725bis-05
+
+* Applied suggestions by responsible AD Deb Cooley.
+
 ## draft-ietf-oauth-rfc8725bis-04
 
 * Applied suggestions by document shepherd Hannes Tschofenig.


### PR DESCRIPTION
Adding just a doc history entry. @selfissued are we ready to publish or do you prefer to hash out the ECDSA question?