### PR TITLE
Made deprecate-none reference normative and rewrote "none" and RSA-PKCS1 v1.5 text accordingly

### DIFF
--- a/draft-ietf-oauth-rfc8725bis.md
+++ b/draft-ietf-oauth-rfc8725bis.md
@@ -526,6 +526,7 @@ encrypted JWTs (JWEs), and
 signed and encrypted JWTs (Nested JWTs).
 This allows recipients to easily apply policies that only accept
 appropriate JWTs for the application context.
+Note that authentication use cases typically require the use of signed JWTs.
 
 ## Validate Cryptographic Inputs {#validate-inputs}
 
@@ -856,6 +857,10 @@ This document obsoletes RFC 8725 and provides several significant improvements a
 6. Explicit Typing: Expanded the guidance on explicit typing by defining recommended `typ` and media type conventions, recipient processing rules, and deployment guidance for new and existing JWT types ({{use-typ}} and {{preventing-confusion}}).
 
 7. Untrusted Header Parameters and SSRF: Added guidance on treating `kid`, `jku`, and `x5u` as potentially attacker-controlled input, including SSRF mitigations and DNS resolution checks when processing untrusted URLs ({{do-not-trust-claims}}).
+
+8. Normatively references {{I-D.ietf-jose-deprecate-none-rsa15}},
+   makes the text requiring application opt-in to use JWTs with algorithm "none" a "MUST",
+   and states that the RSA-PKCS1 v1.5 algorithms are deprecated.
 
 # Document History
 

--- a/draft-ietf-oauth-rfc8725bis.md
+++ b/draft-ietf-oauth-rfc8725bis.md
@@ -15,6 +15,7 @@ author:
   organization: Self-Issued Consulting
   uri: https://self-issued.info/
 category: bcp
+consensus: true
 docname: draft-ietf-oauth-rfc8725bis-latest
 ipr: trust200902
 obsoletes: 8725
@@ -56,7 +57,6 @@ venue:
   arch: "https://mailarchive.ietf.org/arch/browse/oauth/"
   github: "oauth-wg/draft-ietf-oauth-rfc8725bis"
 
-
 normative:
   RFC6979:
   RFC7515:
@@ -68,6 +68,8 @@ normative:
   RFC8037:
   RFC8259:
   nist-sp-800-56a-r3: DOI.10.6028/NIST.SP.800-56Ar3
+  I-D.ietf-jose-deprecate-none-rsa15:
+
 informative:
   ANSI-X962-2005:
     author:
@@ -172,33 +174,29 @@ informative:
     seriesinfo: OWASP Cheat Sheet Series
     target: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
     date: 2025
-  I-D.ietf-jose-deprecate-none-rsa15:
 
 --- abstract
 
+JSON Web Tokens, also known as JWTs, are URL-safe JSON-based security
+tokens that contain a set of claims that can be signed and/or encrypted.
+JWTs are being widely used and deployed as a simple security token
+format in numerous protocols and applications, both in the area of
+digital identity and in other application areas.  This Best Current
+Practices (BCP) specification updates RFC 7519 to provide actionable guidance
+leading to secure implementation and deployment of JWTs.
 
- JSON Web Tokens, also known as JWTs, are URL-safe JSON-based security
- tokens that contain a set of claims that can be signed and/or encrypted.
- JWTs are being widely used and deployed as a simple security token
- format in numerous protocols and applications, both in the area of
- digital identity and in other application areas.  This Best Current
- Practices (BCP) specification updates RFC 7519 to provide actionable guidance
- leading to secure implementation and deployment of JWTs.
-
- This BCP specification furthermore obsoletes the existing JWT BCP
- specification RFC 8725 to provide additional actionable guidance
- covering threats and attacks that have been discovered
- since RFC 8725 was published.
+This BCP specification furthermore obsoletes the existing JWT BCP
+specification RFC 8725 to provide additional actionable guidance
+covering threats and attacks that have been discovered
+since RFC 8725 was published.
 
 
 --- middle
 
 
-
 # Introduction {#introduction}
 
-
- JSON Web Tokens, also known as JWTs  {{RFC7519}}, are URL-safe JSON-based security tokens
+JSON Web Tokens, also known as JWTs {{RFC7519}}, are URL-safe JSON-based security tokens
 that contain a set of claims that can be signed and/or encrypted.
 The JWT specification has seen rapid adoption because it encapsulates
 security-relevant information in one easy-to-protect location, and because
@@ -208,20 +206,20 @@ representing authorization information, such as OAuth 2.0 access tokens {{RFC906
 and identity information, such as OpenID Connect ID Tokens {{OpenID.Core}}.
 The details of these uses are application- and deployment-specific.
 
- Since the JWT specification was published, there have been several widely published
+Since the JWT specification was published, there have been several widely published
 attacks on implementations and deployments.
 Such attacks are the result of under-specified security mechanisms, as well as incomplete
 implementations and incorrect usage by applications.
 
- The goal of this document is to facilitate secure implementation and deployment of JWTs.
+The goal of this document is to facilitate secure implementation and deployment of JWTs.
 Many of the recommendations in this document are about
 implementation and use of the cryptographic mechanisms underlying JWTs that are defined by
-JSON Web Signature (JWS)  {{RFC7515}},
-JSON Web Encryption (JWE)  {{RFC7516}}, and
-JSON Web Algorithms (JWA)  {{RFC7518}}.
+JSON Web Signature (JWS) {{RFC7515}},
+JSON Web Encryption (JWE) {{RFC7516}}, and
+JSON Web Algorithms (JWA) {{RFC7518}}.
 Others are about use of the JWT claims themselves.
 
- These are intended to be minimum recommendations for the use of JWTs
+These are intended to be minimum recommendations for the use of JWTs
 in the vast majority of implementation
 and deployment scenarios. Other specifications that reference this document can have
 stricter requirements related to one or more aspects of the format, based on their
@@ -230,7 +228,7 @@ to those stricter requirements. Furthermore, this document provides a floor, not
 so stronger options are always allowed (e.g., depending on differing evaluations of the
 importance of cryptographic strength vs. computational load).
 
- Community knowledge about the strength of various algorithms and feasible attacks can
+Community knowledge about the strength of various algorithms and feasible attacks can
 change quickly, and experience shows that a Best Current Practice (BCP) document about
 security is a point-in-time statement. Readers are advised to seek out any errata or
 updates that apply to this document.
@@ -245,21 +243,16 @@ audience, issuer/subject, and explicit typing), and by restricting how Unsecured
 
 ## Target Audience {#target-audience}
 
-
- The intended audiences of this document are:
-
+The intended audiences of this document are:
 
  * Implementers of JWT libraries (and the JWS and JWE libraries
- used by those libraries),
+   used by those libraries),
 
  * Implementers of code that uses such libraries (to the extent that some mechanisms may
-not be provided by libraries, or until they are), and
+   not be provided by libraries, or until they are), and
 
  * Developers of specifications that rely on JWTs, both inside and
- outside the IETF.
-
-
-
+   outside the IETF.
 
 
 ## Conventions Used in this Document {#conventions-used-in-this-document}
@@ -267,50 +260,41 @@ not be provided by libraries, or until they are), and
 {::boilerplate bcp14-tagged}
 
 
-
-
 # Threats and Vulnerabilities {#threats-and-vulnerabilities}
 
-
- This section lists some known and possible problems with JWT
- implementations and deployments.
+This section lists some known and possible problems with JWT
+implementations and deployments.
 Each problem description is followed by references to one or more mitigations to those problems.
 
 
 ## Weak Signatures and Insufficient Signature Validation {#weak-signatures-and-insufficient-signature-validation}
 
-
- Signed JSON Web Tokens carry an explicit indication of the signing algorithm,
+Signed JSON Web Tokens carry an explicit indication of the signing algorithm,
 in the form of the "alg" Header Parameter, to facilitate cryptographic agility.
 This, in conjunction with design flaws in some libraries and applications,
- has led to several attacks:
-
+has led to several attacks:
 
  * The algorithm can be changed to "none" by an attacker, and some libraries would trust
-this value and "validate" the JWT without checking any signature.
+   this value and "validate" the JWT without checking any signature.
 
  * An "RS256" (RSA, 2048 bit) parameter value can be changed into
-"HS256" (HMAC, SHA-256), and some libraries
-would try to validate the signature using HMAC-SHA256 and using the RSA public key as the
-HMAC shared secret (see  {{McLean}} and
-  {{CVE-2015-9235}}).
+   "HS256" (HMAC, SHA-256), and some libraries
+   would try to validate the signature using HMAC-SHA256 and using the RSA public key
+   as the HMAC shared secret (see {{McLean}} and {{CVE-2015-9235}}).
 
-For mitigations, see {{algorithm-verification}} and {{appropriate-algorithms}}.
+For mitigations, see Sections {{<algorithm-verification}} and {{<appropriate-algorithms}}.
 
 
 ## Weak Symmetric Keys {#weak-symmetric-keys}
 
-
- In addition, some applications use a keyed Message Authentication
- Code (MAC) algorithm, such as
+In addition, some applications use a keyed Message Authentication
+Code (MAC) algorithm, such as
 "HS256", to sign tokens but supply a weak symmetric key with
 insufficient entropy (such as a human-memorable password). Such keys
 are vulnerable to offline brute-force or dictionary attacks once an
-attacker gets hold of such a token  {{Langkemper}}{{JWT-Cracker}}.
+attacker gets hold of such a token {{Langkemper}}{{JWT-Cracker}}.
 
- For mitigations, see  {{key-entropy}}.
-
-
+For mitigations, see {{key-entropy}}.
 
 
 ## Incorrect Use and Composition of Encryption and Signature {#incorrect-composition-of-encryption-and-signature}
@@ -320,13 +304,12 @@ Most authentication use cases only require a simple signed JWT as their token. H
 In the more complicated use cases where confidentiality is required, some libraries that decrypt a JWE-encrypted JWT to obtain a JWS-signed object
 do not always validate the internal signature.
 
-For mitigations, see  {{validate-crypto}}.
+For mitigations, see {{validate-crypto}}.
 
 ## Plaintext Leakage through Analysis of Ciphertext Length {#plaintext-leakage-through-analysis-of-ciphertext-length}
 
-
- Many encryption algorithms leak information about the length of the
- plaintext, with a varying amount of
+Many encryption algorithms leak information about the length of the
+plaintext, with a varying amount of
 leakage depending on the algorithm and mode of operation. JWEs are vulnerable to this leakage. This problem is exacerbated
 when the plaintext is initially compressed, because the length of the
 compressed plaintext and, thus,
@@ -337,69 +320,57 @@ Compression attacks are particularly
 powerful when there is attacker-controlled data in the same compression
 space as secret data, which is the case for some attacks on HTTPS.
 
- See  {{Kelsey}} for general background
-on compression and encryption and  {{Alawatugoda}} for a specific example of attacks on HTTP cookies.
+See {{Kelsey}} for general background
+on compression and encryption and {{Alawatugoda}} for a specific example of attacks on HTTP cookies.
 
- For mitigations, see  {{no-compression}}.
-
-
+For mitigations, see {{no-compression}}.
 
 
 ## Insecure Use of Elliptic Curve Encryption {#insecure-use-of-elliptic-curve-encryption}
 
-
- Per  {{Sanso}}, several Javascript
- Object Signing and Encryption (JOSE) libraries
- fail to validate their inputs correctly
+Per {{Sanso}}, several JavaScript
+Object Signing and Encryption (JOSE) libraries
+fail to validate their inputs correctly
 when performing elliptic curve key agreement (the "ECDH-ES" algorithm).
 An attacker that is able to send JWEs of its choosing that use invalid curve points and
 observe the cleartext outputs resulting from decryption with the invalid curve points
 can use this vulnerability to recover the recipient's private key.
 
- For mitigations, see  {{validate-inputs}}.
-
-
+For mitigations, see {{validate-inputs}}.
 
 
 ## Multiplicity of JSON Encodings {#multiplicity-of-json-encodings}
 
-
- Previous versions of the JSON format, such as the obsoleted  {{RFC7159}},
+Previous versions of the JSON format, such as the obsoleted {{RFC7159}},
 allowed several different character
 encodings: UTF-8, UTF-16, and UTF-32. This is not the case anymore, with the latest
-standard  {{RFC8259}} only allowing UTF-8 except
+standard {{RFC8259}} only allowing UTF-8 except
 for internal use within a "closed ecosystem".
 This ambiguity, where older implementations and those used within closed environments may generate
 non-standard encodings, may result in the JWT being
 misinterpreted by its recipient. This, in turn, could be used by a malicious sender to bypass
 the recipient's validation checks.
 
- For mitigations, see  {{use-utf8}}.
-
-
+For mitigations, see {{use-utf8}}.
 
 
 ## Substitution Attacks {#substitution}
 
-
- There are attacks in which one recipient will be given a JWT that was intended for it
+There are attacks in which one recipient will be given a JWT that was intended for it
 and will attempt to use it at a different recipient for which that JWT was not intended.
-For instance, if an OAuth 2.0  {{RFC6749}} access
+For instance, if an OAuth 2.0 {{RFC6749}} access
 token is legitimately presented to an
 OAuth 2.0 protected resource for which it is intended, that protected resource might then present
 that same access token to a different protected resource for which the access token is not intended,
 in an attempt to gain access. If such situations are not caught, this can result in
 the attacker gaining access to resources that it is not entitled to access.
 
- For mitigations, see Sections  {{<validate-iss-sub}} and  {{<use-aud}}.
-
-
+For mitigations, see Sections {{<validate-iss-sub}} and {{<use-aud}}.
 
 
 ## Cross-JWT Confusion {#cross-jwt-confusion}
 
-
- As JWTs are used by more protocols in diverse ways, it becomes increasingly
+As JWTs are used by more protocols in diverse ways, it becomes increasingly
 important to prevent JWT tokens that have been issued for one purpose
 being used for another.
 Note that this is a specific type of substitution attack.
@@ -407,20 +378,17 @@ If the JWT could be used in an application context in which it could be
 confused with other kinds of JWTs,
 then mitigations can be employed to prevent these substitution attacks.
 
-For mitigations, see Sections  {{<validate-iss-sub}},  {{<use-aud}},  {{<use-typ}}, and  {{<preventing-confusion}}.
-
-
+For mitigations, see Sections {{<validate-iss-sub}}, {{<use-aud}}, {{<use-typ}}, and {{<preventing-confusion}}.
 
 
 ## Indirect Attacks on the Server {#indirect-attacks-on-the-server}
 
-
- Various JWT claims are used by the recipient to perform lookup operations,
+Various JWT claims are used by the recipient to perform lookup operations,
 such as database and Lightweight Directory Access Protocol (LDAP) searches.
 Others include URLs that are similarly looked up by the server. Any of these claims can be used by
 an attacker as vectors for injection attacks or server-side request forgery (SSRF) attacks.
 
- For mitigations, see  {{do-not-trust-claims}}.
+For mitigations, see {{do-not-trust-claims}}.
 
 ## Computation Cost of Unreasonable Number of Hash Iterations {#unreasonable-iterations}
 
@@ -445,7 +413,6 @@ For mitigations, see {{algorithm-verification}}.
 
 ## JWE Decompression Bomb Attack {#jwe-decompression-bomb}
 
-
 JWE supports the optional compression of the plaintext prior to encryption via the "zip" header parameter as defined in {{RFC7516}} Section 4.1.3. Upon decryption, recipients are expected to decompress the payload before further processing. However, if the recipient does not enforce limits on the size of the decompressed output, an attacker can craft a malicious JWE with a highly compressed, arbitrarily large payload. This can cause excessive resource consumption (CPU, memory), resulting in Denial of Service (DoS).
 
 For mitigation, see {{limit-decompression}}.
@@ -460,8 +427,7 @@ For mitigations, see {{token-format}}.
 
 # Best Practices {#BP}
 
-
- The best practices listed below should be applied by practitioners
+The best practices listed below should be applied by practitioners
 to mitigate the threats listed in the preceding section.
 
 
@@ -495,55 +461,51 @@ cannot anticipate every unsafe or misspelled value an attacker might use.
 
 ## Use Appropriate Algorithms {#appropriate-algorithms}
 
-
- As  Section 5.2 of {{RFC7515}} says,
+As {{Section 5.2 of RFC7515}} says,
 "it is an application decision which algorithms may
 be used in a given context. Even if a JWS can be successfully
 validated, unless the algorithm(s) used in the JWS are acceptable to
-the application, it  SHOULD consider the JWS to be invalid."
+the application, it SHOULD consider the JWS to be invalid."
 
- Therefore, applications  MUST only allow the use of
- cryptographically current algorithms
+Therefore, applications MUST only allow the use of
+cryptographically current algorithms
 that meet the security requirements of the application.
 This set will vary over time as new algorithms are introduced
 and existing algorithms are deprecated due to discovered cryptographic weaknesses.
-Applications  MUST therefore be designed to enable cryptographic agility.
+Applications MUST therefore be designed to enable cryptographic agility.
 
 The "none" algorithm should only be used when the JWT is cryptographically protected by other means.
 JWTs using "none" are often used in application contexts in which the content is optionally signed.
 The URL-safe claims representation and processing in this context can be the same in both
 the signed and unsigned cases.
-JWT libraries  SHOULD NOT generate JWTs using "none" unless
-explicitly requested to do so by the caller.
-Similarly, JWT libraries  SHOULD NOT consume JWTs using "none"
- unless explicitly requested by the caller.
 
- Applications  SHOULD follow these algorithm-specific recommendations,
+The "none" algorithm is deprecated by {{I-D.ietf-jose-deprecate-none-rsa15}}.
+JWT libraries MUST NOT generate JWTs using "none" unless
+explicitly requested to do so by the caller.
+Similarly, JWT libraries MUST NOT consume JWTs using "none"
+unless explicitly allowed by the caller.
+
+Applications SHOULD follow these algorithm-specific recommendations,
 because deviating from them may re-enable known attacks on the listed algorithms
 unless an application-specific threat analysis shows the risk is acceptable:
 
+ * Deprecate all RSA-PKCS1 v1.5 encryption algorithms ({{Section 7.2 of RFC8017}}),
+   as specified in {{I-D.ietf-jose-deprecate-none-rsa15}},
+   preferring RSAES-OAEP ({{Section 7.1 of RFC8017}}).
 
- * Avoid all RSA-PKCS1 v1.5 encryption algorithms ({{RFC8017}}, Section 7.2), preferring
- RSAES-OAEP
- ({{RFC8017}}, Section 7.1).
-
- * Elliptic Curve Digital Signature Algorithm (ECDSA) signatures  {{ANSI-X962-2005}} require a unique random value for
-every message
- that is signed.
-If even just a few bits of the random value are predictable across multiple messages, then
-the security of the signature scheme may be compromised. In the worst case,
-the private key may be recoverable by an attacker. To counter these attacks,
-JWT libraries  SHOULD implement ECDSA using the deterministic
-approach defined in  {{RFC6979}}, unless this is not reasonably implementable.
-This approach is completely compatible with existing ECDSA verifiers and so can be implemented
-without new algorithm identifiers being required.
-
-Readers are advised that {{I-D.ietf-jose-deprecate-none-rsa15}}
-proposes deprecating the "none" and "RSA1_5" algorithms.
+ * Elliptic Curve Digital Signature Algorithm (ECDSA) signatures {{ANSI-X962-2005}} require a unique random value for
+   every message that is signed.
+   If even just a few bits of the random value are predictable across multiple messages, then
+   the security of the signature scheme may be compromised. In the worst case,
+   the private key may be recoverable by an attacker. To counter these attacks,
+   JWT libraries SHOULD implement ECDSA using the deterministic
+   approach defined in {{RFC6979}}, unless this is not reasonably implementable.
+   This approach is completely compatible with existing ECDSA verifiers and so can be implemented
+   without new algorithm identifiers being required.
 
 Readers are advised that {{?RFC9864}} defines fully-specified JOSE
 algorithm identifiers and deprecates polymorphic identifiers such as "EdDSA".
-New deployments SHOULD prefer fully-specified identifiers (for example,
+New deployments SHOULD prefer fully-specified algorithm identifiers (for example,
 "Ed25519" rather than "EdDSA") when negotiating and configuring algorithms,
 unless backward compatibility requires use of the older polymorphic identifiers.
 
@@ -557,52 +519,51 @@ If an implementation supports Nested JWTs, as defined in {{Section 2 of RFC7519}
 then both the outer and inner operations MUST be validated
 using the keys and algorithms supplied by the application.
 
-Libraries MUST allow the verifier to distinguish between signed JWTs (JWSes) and encrypted JWTs (JWEs).
-This allows verifiers to easily establish a policy of only accepting signed JWTs.
+Libraries MUST allow the recipient to distinguish between
+Unsecured JWTs,
+signed JWTs (JWSes),
+encrypted JWTs (JWEs), and
+signed and encrypted JWTs (Nested JWTs).
+This allows recipients to easily apply policies that only accept
+appropriate JWTs for the application context.
 
 ## Validate Cryptographic Inputs {#validate-inputs}
 
-
- Some cryptographic operations, such as Elliptic Curve Diffie-Hellman key agreement
+Some cryptographic operations, such as Elliptic Curve Diffie-Hellman key agreement
 ("ECDH-ES"), take inputs that may contain invalid values. This includes points not on
 the specified elliptic curve
-or other invalid points (e.g.,  {{Valenta}}, Section 7.1).
+or other invalid points (e.g., Section 7.1 of {{Valenta}}).
 The JWS/JWE library MUST validate these inputs before using them or use
 underlying cryptographic libraries that do so (or both).
 
- Elliptic Curve Diffie-Hellman Ephemeral Static (ECDH-ES) ephemeral
- public key (epk) inputs should be validated
- according to the recipient's
+Elliptic Curve Diffie-Hellman Ephemeral Static (ECDH-ES) ephemeral
+public key (epk) inputs should be validated
+according to the recipient's
 chosen elliptic curve. For the NIST prime-order curves P-256, P-384, and P-521,
-validation  MUST
+validation MUST
 be performed according to Section 5.6.2.3.4 (ECC Partial Public-Key Validation
 Routine) of "Recommendation for Pair-Wise Key-Establishment Schemes Using Discrete Logarithm Cryptography"
 {{nist-sp-800-56a-r3}}.
-If the "X25519" or "X448"  {{RFC8037}} algorithms are used,
-then the security considerations in  {{RFC8037}} apply.
-
-
+If the "X25519" or "X448" {{RFC8037}} algorithms are used,
+then the security considerations in {{RFC8037}} apply.
 
 
 ## Ensure Cryptographic Keys Have Sufficient Entropy {#key-entropy}
 
-
- The Key Entropy and Random Values advice in  Section 10.1 of {{RFC7515}}, the
- Password Considerations in  Section 8.8 of {{RFC7518}}, and PBKDF2 as specified in {{RFC8018}}
-  MUST be followed.
-In particular, human-memorizable passwords  MUST NOT be directly used
+The Key Entropy and Random Values advice in {{Section 10.1 of RFC7515}},
+the Password Considerations in {{Section 8.8 of RFC7518}},
+and PBKDF2 as specified in {{RFC8018}}
+MUST be followed.
+In particular, human-memorizable passwords MUST NOT be directly used
 as the key to a keyed-MAC algorithm such as "HS256".
 Moreover, passwords should only be used to perform key encryption, rather
 than content encryption,
-as described in  Section 4.8 of {{RFC7518}}.
+as described in {{Section 4.8 of RFC7518}}.
 Note that even when used for key encryption, password-based encryption is
- still subject to brute-force attacks.
-
-
+still subject to brute-force attacks.
 
 
 ## Avoid Compression of Encryption Inputs {#no-compression}
-
 
 Compression of data SHOULD NOT be used when creating a JWE, because
 such compressed data often reveals information about the plaintext,
@@ -612,35 +573,31 @@ threat model.
 
 ## Use UTF-8 {#use-utf8}
 
-
- {{RFC7515}},  {{RFC7516}}, and  {{RFC7519}} all
- specify that UTF-8 be used for encoding and decoding JSON
+{{RFC7515}}, {{RFC7516}}, and {{RFC7519}} all
+specify that UTF-8 be used for encoding and decoding JSON
 used in Header Parameters and JWT Claims Sets. This is also in line with the
-latest JSON specification  {{RFC8259}}.
+latest JSON specification {{RFC8259}}.
 Implementations and applications MUST do this and not use or allow the use of
 other Unicode encodings for these purposes.
 
 
-
-
 ## Validate Issuer and Subject {#validate-iss-sub}
 
-
- When a JWT contains an "iss" (issuer) claim, the application
-  MUST validate that the cryptographic keys
+When a JWT contains an "iss" (issuer) claim, the application
+MUST validate that the cryptographic keys
 used for the cryptographic operations in the JWT belong to the issuer.
-If they do not, the application  MUST reject the JWT.
+If they do not, the application MUST reject the JWT.
 
- The means of determining the keys owned by an issuer is application-specific.
+The means of determining the keys owned by an issuer is application-specific.
 As one example, OAuth 2.0 authorization server "issuer" values {{RFC8414}}
 are "https" URLs
 that reference a JSON metadata document that contains a "jwks_uri" value that is
-an "https" URL from which the issuer's keys are retrieved as a JWK Set  {{RFC7517}}.
+an "https" URL from which the issuer's keys are retrieved as a JWK Set {{RFC7517}}.
 This same mechanism is used by OpenID Connect {{OpenID.Core}}.
 Other applications may use different means of binding keys to issuers.
 
- Similarly, when the JWT contains a "sub" (subject) claim, the
- application  MUST validate that
+Similarly, when the JWT contains a "sub" (subject) claim, the
+application MUST validate that
 the subject value corresponds to a valid subject and/or issuer-subject pair at the application.
 This may include confirming that the issuer is trusted by the application.
 In the OAuth context, {{Section 4.15 of RFC9700}} discusses the possibility of
@@ -649,14 +606,11 @@ If the issuer, subject, or the pair are invalid, the application
   MUST reject the JWT.
 
 
-
-
 ## Use and Validate Audience {#use-aud}
 
-
- If the same issuer can issue JWTs that are intended for use by more
- than one relying party or application, or may do so in the future,
-the JWT  MUST contain an "aud" (audience) claim that can be used
+If the same issuer can issue JWTs that are intended for use by more
+than one relying party or application, or may do so in the future,
+the JWT MUST contain an "aud" (audience) claim that can be used
 to determine whether the JWT
 is being used by an intended party or was substituted by an attacker.
 
@@ -667,11 +621,11 @@ value is present or none of the values are associated with the recipient, it MUS
 
 Treat claim values as being potentially attacker-provided input.
 
- The "kid" (key ID) header is used by the relying application to
- perform key lookup. Applications MUST ensure that this does not create SQL or LDAP injection vulnerabilities by validating
+The "kid" (key ID) header is used by the relying application to
+perform key lookup. Applications MUST ensure that this does not create SQL or LDAP injection vulnerabilities by validating
 and/or sanitizing the received value.
 
- Similarly, blindly following a "jku" (JWK set URL) or "x5u" (X.509 URL) header,
+Similarly, blindly following a "jku" (JWK set URL) or "x5u" (X.509 URL) header,
 which may contain an arbitrary URL,
 could result in server-side request forgery (SSRF) attacks. Applications SHOULD protect against such
 attacks, e.g., by matching the URL to an allowlist of permitted locations
@@ -695,7 +649,7 @@ kind of JWT is subject to such confusion, that JWT can include an explicit
 JWT type value, and the validation rules can specify checking the type.
 This mechanism can prevent such confusion.
 Explicit JWT typing is accomplished by using the "typ" Header Parameter.
-For instance, the  {{RFC8417}} specification uses
+For instance, the {{RFC8417}} specification uses
 the "application/secevent+jwt" media type
 to perform explicit typing of Security Event Tokens (SETs).
 
@@ -707,7 +661,7 @@ The use of explicit typing avoids the need for employing such ad-hoc mechanisms
 when the validation rules for both kinds of JWTs include validating the "typ" values
 and the acceptable "typ" values for the two kinds of JWTs are distinct.
 
-Per Section 4.1.9 of {{RFC7515}}, the "typ" Header Parameter declares the
+Per {{Section 4.1.9 of RFC7515}}, the "typ" Header Parameter declares the
 media type of the complete JWS.
 To keep header values compact, producers are RECOMMENDED to omit the
 "application/" prefix from "typ" when no other "/" appears in the media type,
@@ -736,14 +690,14 @@ For example, for Security Event Tokens (SETs) {{RFC8417}}, the media type is
 SETs are often issued in contexts where they could otherwise be mistaken for
 other kinds of JWTs.
 
- When applying explicit typing to a Nested JWT, the "typ" Header
- Parameter containing the explicit type value  MUST be present in the inner JWT of the Nested JWT (the JWT
+When applying explicit typing to a Nested JWT, the "typ" Header
+Parameter containing the explicit type value MUST be present in the inner JWT of the Nested JWT (the JWT
 whose payload is the JWT Claims Set).
 In some cases, the same "typ" Header Parameter value will be present in the outer JWT as well,
 to explicitly type the entire Nested JWT.
 
- Note that the use of explicit typing may not achieve disambiguation
- from existing kinds of JWTs,
+Note that the use of explicit typing may not achieve disambiguation
+from existing kinds of JWTs,
 as the validation rules for kinds of JWTs defined before
 the guidance on explicit typing in {{RFC8725}} was available
 often do not use the "typ" Header Parameter value.
@@ -768,49 +722,45 @@ confusion becomes more likely.
 
 ## Use Mutually Exclusive Validation Rules for Different Kinds of JWTs {#preventing-confusion}
 
-
- Each application of JWTs defines a profile specifying the required
- and optional JWT claims
+Each application of JWTs defines a profile specifying the required
+and optional JWT claims
 and the validation rules associated with them.
 If more than one kind of JWT can be issued by the same issuer,
-the validation rules for those JWTs  MUST be written such that
+the validation rules for those JWTs MUST be written such that
 they are mutually exclusive,
 rejecting JWTs of the wrong kind.
 
 To prevent substitution of JWTs from one context into another,
 application developers may employ a number of strategies:
 
-
  * Use explicit typing for different kinds of JWTs.
-Then the distinct "typ" values can be used to differentiate between the
- different kinds of JWTs.
+   Then the distinct "typ" values can be used to differentiate between the
+   different kinds of JWTs.
 
  * Use different sets of required claims or different required claim values.
-Then the validation rules for one kind of JWT will reject those with different
- claims or values.
+   Then the validation rules for one kind of JWT will reject those with different
+   claims or values.
 
  * Use different sets of required Header Parameters or different
- required Header Parameter values.
-Then the validation rules for one kind of JWT will reject those with different
- Header Parameters or values.
+   required Header Parameter values.
+   Then the validation rules for one kind of JWT will reject those with different
+   Header Parameters or values.
 
  * Use different keys for different kinds of JWTs.
-Then the keys used to validate one kind of JWT will fail to validate other kinds of JWTs.
+   Then the keys used to validate one kind of JWT will fail to validate other kinds of JWTs.
 
  * Use different "aud" values for different uses of JWTs from the same issuer.
-Then audience validation will reject JWTs substituted into inappropriate contexts.
+   Then audience validation will reject JWTs substituted into inappropriate contexts.
 
  * Use different issuers for different kinds of JWTs.
-Then the distinct "iss" values can be used to segregate the different kinds of JWTs.
+   Then the distinct "iss" values can be used to segregate the different kinds of JWTs.
 
-
- Given the broad diversity of JWT usage and applications,
+Given the broad diversity of JWT usage and applications,
 the best combination of types, required claims, values, Header Parameters, key usages, and issuers
 to differentiate among different kinds of JWTs
 will, in general, be application-specific.
-As discussed in  {{use-typ}}, for new JWT
- applications, the use of explicit typing is
-  RECOMMENDED.
+As discussed in {{use-typ}}, for new JWT applications,
+the use of explicit typing is RECOMMENDED.
 
 
 ## Limit Hash Iteration Count {#limit-iterations}
@@ -842,23 +792,13 @@ because without such a limit, decompression can impose an unreasonable memory or
 
 # Security Considerations {#security-considerations}
 
-
- This entire document is about security considerations when
- implementing and deploying JSON Web Tokens.
-
-
+This entire document is about security considerations when
+implementing and deploying JSON Web Tokens.
 
 
 # IANA Considerations {#iana-considerations}
 
-
- This document has no IANA actions.
-
-
-
-
-
-
+This document has no IANA actions.
 
 
 # Acknowledgements {#acknowledgements}
@@ -868,12 +808,12 @@ because without such a limit, decompression can impose an unreasonable memory or
 The following acknowledgements from {{RFC8725}},
 the text of which is incorporated into this specification, are retained.
 
- Thanks to  Antonio Sanso for bringing the
- "ECDH-ES" invalid point attack to the attention
+Thanks to Antonio Sanso for bringing the
+"ECDH-ES" invalid point attack to the attention
 of JWE and JWT implementers.  Tim McLean published the
-RSA/HMAC confusion attack  {{McLean}}.
-Thanks to  Nat Sakimura for advocating the use of
-explicit typing. Thanks to  Neil Madden for his
+RSA/HMAC confusion attack {{McLean}}.
+Thanks to Nat Sakimura for advocating the use of
+explicit typing. Thanks to Neil Madden for his
 numerous comments, and to Carsten Bormann, Brian Campbell, Brian Carpenter, Alissa Cooper, Roman Danyliw, Ben Kaduk,
 Mirja Kühlewind, Barry Leiba,
 Dan Moore,
@@ -927,6 +867,11 @@ This document obsoletes RFC 8725 and provides several significant improvements a
 * Applied IESG ballot comments by Ketan Talaulikar (Introduction relationships, Compact Serialization and `typ` prefix citations).
 * Updated Appendix A (Changes from RFC 8725) with complete bullets and section references.
 * Added an informative mention of fully-specified JOSE algorithm identifiers ({{?RFC9864}}).
+* Made the {{I-D.ietf-jose-deprecate-none-rsa15}} reference normative and
+  rewrote the text on "alg":"none" and RSA-PKCS1 v1.5 accordingly.
+* Corrected section reference and itemized list syntax and
+  removed extraneous spaces in the source.
+* Applied spelling and grammar corrections.
 
 ## draft-ietf-oauth-rfc8725bis-07
 
@@ -935,7 +880,7 @@ This document obsoletes RFC 8725 and provides several significant improvements a
 
 ## draft-ietf-oauth-rfc8725bis-06
 
-* AD review followup: promoted selected lowercase must/should guidance to normative MUST language.
+* AD review follow-up: Promoted selected lowercase must/should guidance to normative MUST language.
 
 ## draft-ietf-oauth-rfc8725bis-05
 


### PR DESCRIPTION
... at @debcooley's request.

The full set of changes in this PR are:
* Made the draft-ietf-jose-deprecate-none-rsa15 reference normative and rewrote the text on "alg":"none" and RSA-PKCS1 v1.5 accordingly.
* Corrected section reference and itemized list syntax and removed extraneous spaces in the source.
* Applied spelling and grammar corrections.