### PR TITLE
Update Yaron Sheffer affiliation to Independent

### DIFF
--- a/draft-ietf-oauth-rfc8725bis.md
+++ b/draft-ietf-oauth-rfc8725bis.md
@@ -5,7 +5,7 @@ author:
 - email: yaronf.ietf@gmail.com
   ins: Y. Sheffer
   name: Yaron Sheffer
-  organization: Intuit
+  organization: Independent
 - email: dick.hardt@gmail.com
   ins: D. Hardt
   name: Dick Hardt


### PR DESCRIPTION
## Summary

Replaces the Intuit organization affiliation for Yaron Sheffer with Independent.

Made with [Cursor](https://cursor.com)