### PR TITLE
Clarify JWE decompression size limit (IESG §3.15)

### DIFF
--- a/draft-ietf-oauth-rfc8725bis.md
+++ b/draft-ietf-oauth-rfc8725bis.md
@@ -787,8 +787,9 @@ marks - is not a JWT and MUST be rejected.
 
 ## Limit JWE Decompression Size {#limit-decompression}
 
-Implementations are RECOMMENDED to set a reasonable upper limit on the decompressed size of a JWE such as 250 KB,
+Implementations are RECOMMENDED to set a reasonable upper limit on the decompressed size of a JWE,
 because without such a limit, decompression can impose an unreasonable memory or CPU burden on recipients.
+Deployed JOSE libraries commonly use limits on the order of a few hundred kilobytes, e.g. 250 KB in one implementation.
 
 
 # Security Considerations {#security-considerations}
@@ -832,6 +833,7 @@ Dan Moore,
 Aaron Parecki,
 Filip Skokan,
 Ketan Talaulikar,
+Mike Bishop,
 Tom Tervoort,
 Enze Wang,
 and
@@ -865,6 +867,10 @@ This document obsoletes RFC 8725 and provides several significant improvements a
 # Document History
 
 [[Note to RFC Editor: please remove before publication.]]
+
+## draft-ietf-oauth-rfc8725bis-09
+
+* Clarified that the JWE decompression size limit is a ballpark drawn from deployed libraries (IESG review).
 
 ## draft-ietf-oauth-rfc8725bis-08
 

--- a/draft-ietf-oauth-rfc8725bis.md
+++ b/draft-ietf-oauth-rfc8725bis.md
@@ -789,7 +789,7 @@ marks - is not a JWT and MUST be rejected.
 
 Implementations are RECOMMENDED to set a reasonable upper limit on the decompressed size of a JWE,
 because without such a limit, decompression can impose an unreasonable memory or CPU burden on recipients.
-Deployed JOSE libraries commonly use limits on the order of a few hundred kilobytes, e.g. 250 KB in one implementation.
+Deployed JOSE libraries commonly use limits on the order of a few hundred kilobytes, e.g., 250 KB in one implementation.
 
 
 # Security Considerations {#security-considerations}


### PR DESCRIPTION
## Summary

Addresses @MikeBishop's comment on the 250 KB figure in Section 3.15 (#60).

The RECOMMENDED requirement remains setting a reasonable upper limit. The specific size is framed as a ballpark from deployed JOSE libraries, not as part of the recommendation.

Also adds Mike Bishop to the acknowledgements and a `-09` history entry.

## Issues

Closes #60

Made with [Cursor](https://cursor.com)